### PR TITLE
Keep workflow alive

### DIFF
--- a/.github/workflows/GetMoarFediverse.yml
+++ b/.github/workflows/GetMoarFediverse.yml
@@ -15,3 +15,5 @@ jobs:
         with:
           config_file: ${{ github.workspace }}/config.json
           api_key: ${{ secrets.FAKERELAY_APIKEY }}
+      - name: Keep workflow alive
+        uses: gautamkrishnar/keepalive-workflow@v1


### PR DESCRIPTION
By default, GitHub disables scheduled workflows, if there hasn't been any commit to the repository for 60 days.

This PR adds a step to the workflow that will automatically add a 'fake' commit to the repository after 50 days without activity, to prevent this suspension.